### PR TITLE
Da/total articles read

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -482,6 +482,10 @@ class User < ApplicationRecord
     name
   end
 
+  def articles_read
+    page_views.group(:article_id).count.length
+  end
+
   private
 
   def index_id

--- a/app/views/shared/_reader_stats.html.erb
+++ b/app/views/shared/_reader_stats.html.erb
@@ -2,7 +2,7 @@
   <p>Number of total visits to the site: </p>
   <p>Number of visits per day: </p>
   <p>Average active time on pages per day: </p>
-  <p>Total articles read: </p>
+  <p>Total articles read: <%= current_user.articles_read %></p>
   <p>Total words read: </p>
   <p>Average articles & words per day: </p>
   <p>Number of comments: </p>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -941,4 +941,16 @@ RSpec.describe User, type: :model do
       expect(user.receives_follower_email_notifications?).to be(true)
     end
   end
+
+  describe "#articles_read" do
+    it "returns a count of articles read" do
+      create_list(:page_view, 5, user: user)
+      expect(user.articles_read).to eq(5)
+    end
+
+    it "does not count the same article twice" do
+      create_list(:page_view, 5, user: user, article: create(:article))
+      expect(user.articles_read).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds `User#articles_read` which returns the number of unique articles a user has visited.

## Related Tickets & Documents
Resolves #28 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
